### PR TITLE
Fixing dataset link; old one doesn't work anymore.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ For the best performance when using your own 3D models, please **ensure that eac
 
 # Dataset
 
-To test the algorithm you can for example use the corresponding dataset available for download at: http://cvmr.mi.hs-rm.de/research/RBOT/
+To test the algorithm you can for example use the corresponding dataset available for download at: https://www.mi.hs-rm.de/~schwan/research/RBOT/
 
 
 # License


### PR DESCRIPTION
The old dataset link gives a 403 error. This pull request replaces with the new dataset link.